### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tests/rules/test_git_two_dashes.py
+++ b/tests/rules/test_git_two_dashes.py
@@ -5,7 +5,7 @@ from tests.utils import Command
 
 @pytest.fixture
 def stderr(meant):
-    return 'error: did you mean `%s` (with two dashes ?)' % meant
+    return 'error: did you mean `{0!s}` (with two dashes ?)'.format(meant)
 
 
 @pytest.mark.parametrize('command', [

--- a/thefuck/rules/brew_unknown_command.py
+++ b/thefuck/rules/brew_unknown_command.py
@@ -25,7 +25,7 @@ def _get_brew_tap_specific_commands(brew_path_prefix):
     brew_taps_path = brew_path_prefix + TAP_PATH
 
     for user in _get_directory_names_only(brew_taps_path):
-        taps = _get_directory_names_only(brew_taps_path + '/%s' % user)
+        taps = _get_directory_names_only(brew_taps_path + '/{0!s}'.format(user))
 
         # Brew Taps's naming rule
         # https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md#naming-conventions-and-limitations


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:thefuck?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:thefuck?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
